### PR TITLE
Fix comment color to match VScode + Add predictive color

### DIFF
--- a/themes/vscode_dark_plus.json
+++ b/themes/vscode_dark_plus.json
@@ -209,7 +209,7 @@
             "font_weight": null
           },
           "punctuation.delimiter": {
-            "color": "#404040",
+            "color": "#ffffff",
             "font_style": null,
             "font_weight": null
           },

--- a/themes/vscode_dark_plus.json
+++ b/themes/vscode_dark_plus.json
@@ -121,7 +121,7 @@
         "modified": "#d7ba7d",
         "modified.background": null,
         "modified.border": null,
-        "predictive": null,
+        "predictive": "#707070",
         "predictive.background": null,
         "predictive.border": null,
         "renamed": null,
@@ -149,12 +149,12 @@
             "font_weight": null
           },
           "comment": {
-            "color": "#505050",
+            "color": "#6a9955",
             "font_style": null,
             "font_weight": null
           },
           "comment.doc": {
-            "color": "#505050",
+            "color": "#6a9955",
             "font_style": null,
             "font_weight": null
           },


### PR DESCRIPTION
Adds predictive color (Copilot) and adds the comment color from VScode

![image](https://github.com/d1y/vscode_dark_plus.zed/assets/52638772/07114dca-ffad-4e4b-9cf6-1ac2dc0b4763)
